### PR TITLE
fix(db): enable SSL for Azure PostgreSQL (env-gated)

### DIFF
--- a/backend/src/config/db.ts
+++ b/backend/src/config/db.ts
@@ -6,6 +6,8 @@ const pool: Pool = new Pool({
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
     port: parseInt(process.env.DB_PORT!),
+    // Azure PostgreSQL exige SSL. Activado por env var para no afectar el dev local.
+    ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
 });
 
 pool.on('error', (err) => {


### PR DESCRIPTION
Habilita SSL en la conexión a PostgreSQL, requerido por **Azure Database for PostgreSQL Flexible Server**.

- Cambio mínimo en `config/db.ts`: `ssl` **condicional**, activado por la env var `DB_SSL=true`.
- **No afecta dev local**: sin `DB_SSL`, la conexión sigue exactamente como hoy (sin SSL).
- `rejectUnauthorized: false` por ahora (cifra el tráfico sin validar el certificado) → endurecer a validación completa con el CA de Azure antes del cutover.