### PR TITLE
fix(db): enable SSL for Azure PostgreSQL (env-gated)

### DIFF
--- a/backend/src/config/db.ts
+++ b/backend/src/config/db.ts
@@ -6,6 +6,8 @@ const pool: Pool = new Pool({
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
     port: parseInt(process.env.DB_PORT!),
+    // Azure PostgreSQL exige SSL. Activado por env var para no afectar el dev local.
+    ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
 });
 
 pool.on('error', (err) => {


### PR DESCRIPTION
Release a `main` del fix de SSL para Azure PostgreSQL.

- `config/db.ts`: conexión SSL **condicional** (`DB_SSL=true`), requerido por Azure Database for PostgreSQL Flexible Server.
- **No afecta dev local**: sin `DB_SSL`, la conexión sigue como hoy.
- `rejectUnauthorized: false` por ahora (staging) → endurecer a validación con el CA de Azure antes del cutover.